### PR TITLE
OctoWorker: Fixed bugs, added tests

### DIFF
--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -373,6 +373,15 @@ function loadSharedRepos() {
 }
 
 /**
+ * Only after we have initialized the web worker and verified the github endpoint works,
+ * should we attempt to fetch repository data
+ */
+function apiInitialized() {
+  repoStateManager.fetch();
+  loadSharedRepos();
+}
+
+/**
  * OctoShelf, a Multi-Repo PR Manager
  *
  * @param {Object} options - OctoShelf options
@@ -393,15 +402,13 @@ export default function OctoShelf(options) {
    */
   initAPIVariables({accessToken, apiUrl, githubUrl});
 
-  repoStateManager.fetch();
-  loadSharedRepos();
-
   loadAnimations(appElement);
-  loadActionPanelListeners(appElement);
+  loadActionPanelListeners();
   loadAppEventListeners();
 }
 
 registerWorkerEventHandles('OctoShelf', {
+  apiInitialized,
   drawPlaceholderRepo,
   animateNewPullRequests,
   updateRepository,


### PR DESCRIPTION
So for the past few days I've noticed an awful bug.  Say you load up
Octoshelf.com, add a few repos, and leave the browser tab open for a bit.

Everything works great!  Now lets say you go home, open up your laptop,
and you end up waiting a minute to find wifi.  Within that minute,
Octoshelf will trigger a refresh, and attempt to get updated data on
the repos.  The way this was originally coded, a `removeRepo` would
get triggered for each of the active repos, removing all the repos
 from the DOM and your localStorage.

Next time you refreshed OctoShelf, it would be empty... definitely
a horrible user experience.

This PR fixes that with 2 fixes:
1. Took out the code that auto removes repos.
2. Don't make github api calls if github api is unavailble.

---

On top of that, I wrote a bunch of tests! ^_______^