### PR TITLE
AddRepo Section

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,10 +79,8 @@ function getAccessToken(req) {
 app.get('/', function (req, res) {
   let query = req.query || {};
   let sharedRepos = query.share || '';
-  let origin = req.protocol + '://' + req.get('host');
   let accessToken = getAccessToken(req);
   let data = Object.assign({}, config, {
-    origin: origin,
     accessToken: accessToken,
     showAppDescription: showAppDescription,
     sharedRepos: sharedRepos
@@ -91,13 +89,11 @@ app.get('/', function (req, res) {
 });
 
 app.get('/auth', function (req, res) {
-  let origin = req.protocol + '://' + req.get('host');
   let query = req.query;
   let code = query.code || '';
   let accessToken = getAccessToken(req);
   let data = Object.assign({}, {
-    accessToken: accessToken,
-    origin: origin
+    accessToken: accessToken
   });
   if (code) {
     let body = Object.assign({}, tokenPayload, {

--- a/public/scripts/addRepo.js
+++ b/public/scripts/addRepo.js
@@ -1,0 +1,124 @@
+/**
+ * Add Repo Section - responsible for posting repositories to the web worker
+ */
+
+import {workerPostMessage, registerWorkerEventHandles} from './conductor';
+const postMessageToWorker = workerPostMessage('AddRepo');
+
+const addRepoForm = document.getElementById('addRepoForm');
+const addRepoInput = document.getElementById('addRepoInput');
+const authStatus = document.getElementById('authStatus');
+const syncAll = document.getElementById('syncAll');
+
+let accessToken = '';
+let apiUrl = 'https://api.github.com';
+let githubUrl = 'https://github.com/';
+let origin = window.location.origin;
+
+let initialFetchMethods = [];
+
+/**
+ * Only after we have initialized the web worker and verified the github endpoint works,
+ * should we attempt to fetch repository data
+ */
+function apiInitialized() {
+  initialFetchMethods.forEach(fetchMethod => fetchMethod());
+}
+
+/**
+ * If the url has the share queryParam, pass in each of the repos.
+ * Example url: /?share=org/repo1,org/repo2,org/repo3
+ * @param {Array} sharedRepos - repos that came from the share query param
+ */
+function loadSharedRepos(sharedRepos) {
+  sharedRepos.filter(repo => repo).forEach(addRepository);
+}
+
+/**
+ * Add a repository to the DOM
+ * @param {String} url - repo url
+ */
+function addRepository(url) {
+  postMessageToWorker('addRepo', url);
+}
+
+/**
+ * Add listeners associated with the addRepo section
+ * @return {Object} listener elements - elements that we binded listeners to
+ */
+export function loadAddRepoListeners() {
+  addRepoForm.addEventListener('submit', function(event) {
+    event.preventDefault();
+    addRepository(addRepoInput.value);
+    addRepoInput.value = '';
+  });
+  addRepoInput.addEventListener('input', function() {
+    if (addRepoInput.value.includes(githubUrl)) {
+      addRepoInput.value = addRepoInput.value.replace(githubUrl, '');
+    }
+    let slashCount = addRepoInput.value.split('/');
+    if (slashCount.length > 1) {
+      addRepoInput.value = `${slashCount[0]}/${slashCount[1]}`;
+    }
+  });
+  if (authStatus) {
+    authStatus.addEventListener('click', function(event) {
+      event.preventDefault();
+      let {href} = event.target;
+      let authWindow = window.open(href, '', '');
+      let timeout = setInterval(function() {
+        authWindow.postMessage('fetchToken', origin);
+      }, 500);
+
+      window.addEventListener('message', function(event) {
+        if (event.origin !== origin) {
+          return;
+        }
+
+        let token = event.data;
+        postMessageToWorker('setAccessToken', token);
+        authStatus.parentNode.removeChild(authStatus);
+        clearTimeout(timeout);
+        event.source.close();
+      });
+    });
+  }
+  syncAll.addEventListener('click', function(event) {
+    event.preventDefault();
+    postMessageToWorker('getAllRepoDetails');
+  });
+
+  return {
+    addRepoForm,
+    addRepoInput,
+    authStatus,
+    syncAll
+  };
+}
+
+/**
+ * When "apiInitialized" is posted, we will call a few initial load repo fns
+ * @param {Object} repoStateManager - localStorage repo state manager
+ * @param {Array} sharedRepos - repos that came from the share query param
+ */
+export function setInitialFetch(repoStateManager, sharedRepos) {
+  initialFetchMethods = [
+    repoStateManager.fetch.bind(repoStateManager, addRepository),
+    loadSharedRepos.bind(loadSharedRepos, sharedRepos)
+  ];
+}
+
+/**
+ * Initialize the app with a bunch of variables defining github endpoints
+ * @param {Object} apiVariables -  Object that defines several github api values
+ */
+export function initAPIVariables(apiVariables) {
+  accessToken = apiVariables.accessToken || accessToken;
+  apiUrl = apiVariables.apiUrl || apiUrl;
+  githubUrl = apiVariables.githubUrl || githubUrl;
+  postMessageToWorker('initAPIVariables', {accessToken, apiUrl, githubUrl});
+}
+
+registerWorkerEventHandles('AddRepo', {
+  apiInitialized
+});

--- a/public/scripts/conductor.js
+++ b/public/scripts/conductor.js
@@ -26,7 +26,7 @@
  *
  */
 
-import {log} from './utiltities';
+import {log} from './utilities';
 
 let registeredFns = {};
 let nameMap = {};

--- a/public/scripts/utilities.js
+++ b/public/scripts/utilities.js
@@ -1,6 +1,8 @@
 
 import {registerWorkerEventHandles} from './conductor';
 
+let logsEnabled = true;
+
 /**
  * Log a message to console (if console exists)
  * @param {String} message - message to log (or group)
@@ -15,7 +17,7 @@ export function log() {
     message = message[0];
   }
 
-  if (console && console.log) {
+  if (console && console.log && logsEnabled) {
     if (console.group && otherMessages.length) {
       console.group(message);
       otherMessages.forEach(msg => console.log(msg));
@@ -46,6 +48,14 @@ export function notify(notifyText, duration = 1000) {
       notifications.removeChild(notification);
     }, 500);
   }, duration);
+}
+
+/**
+ * Logs are super noisy during tests.
+ * This helper function blocks console output
+ */
+export function shh() {
+  logsEnabled = false;
 }
 
 registerWorkerEventHandles('Utility', {log, notify});

--- a/tests/actionPanel.js
+++ b/tests/actionPanel.js
@@ -10,6 +10,8 @@ let updateShareLink;
 let loadActionPanelListeners;
 
 function resetDOMAndActionPanel() {
+  let {shh} = require('../public/scripts/utilities');
+  shh();
   global.document = require('jsdom').jsdom(`
     <div id="octoshelf"><div id="repoSection"></div></div>
     <span class="infoPanel-actions">

--- a/tests/addRepo.js
+++ b/tests/addRepo.js
@@ -1,0 +1,327 @@
+
+import 'babel-register';
+import test from 'ava';
+import './helpers/setup-browser-env.js';
+
+import {registerWorker} from '../public/scripts/conductor';
+
+let loadAddRepoListeners;
+let setInitialFetch;
+let initAPIVariables;
+
+/**
+ * Return a fake worker. We aren't testing communicating back and forth between
+ * the worker and other modules, so all we really need to do is spoof a worker
+ * by passing in addEventListener and postMessage functions.
+ * @param {Function} addEventListener - gets called when worker is registered
+ * @param {Function} postMessage - gets called when modules do a postMessage to conductor
+ * @return {Object} Fake Worker
+ */
+function getWorker(addEventListener, postMessage) {
+  return {
+    fns: {},
+    addEventListener,
+    postMessage
+  };
+}
+
+test.beforeEach(() => {
+  let {shh} = require('../public/scripts/utilities');
+  shh();
+  global.document = require('jsdom').jsdom(`
+    <div id="octoshelf">
+    <section id="addSection" class="app-prompt">
+        <form id="addRepoForm" class="bubble">
+            <img class="octoshelf-icon" src="/images/octoshelf-icon.png" alt="OctoShelf, a GitHub powered pull request manager" />
+            <div class="addRepoInput-wrapper">
+                <div class="addRepoInput-prefix">githubUrl</div>
+                <input type="text" id="addRepoInput" class="addRepoInput-input" placeholder="Repository Url" />
+            </div>
+            <div>
+                <a href="#" id="syncAll" class="octicon octicon-sync"></a>
+                <a href="#" id="authStatus" class="octicon octicon-alert tokenNeeded-anchor"></a>
+            </div>
+        </form>
+    </section>
+    </div>
+   `);
+  delete require.cache[require.resolve('../public/scripts/addRepo')];
+  let addRepo = require('../public/scripts/addRepo');
+  loadAddRepoListeners = addRepo.loadAddRepoListeners;
+  setInitialFetch = addRepo.setInitialFetch;
+  initAPIVariables = addRepo.initAPIVariables;
+});
+
+test('initAPIVariables should postMessage api variables to the web worker', t => {
+  let addEventListener = () => {};
+  let postMessage = (result) => {
+    let [fnName, fnData] = result;
+    let {postData} = JSON.parse(fnData);
+    let { accessToken, apiUrl, githubUrl } = postData;
+    t.is(fnName, 'initAPIVariables');
+    t.is(accessToken, 'accessToken');
+    t.is(apiUrl, 'apiUrl');
+    t.is(githubUrl, 'githubUrl');
+  };
+  let worker = getWorker(addEventListener, postMessage);
+
+  registerWorker(worker);
+  initAPIVariables({accessToken: 'accessToken', apiUrl: 'apiUrl', githubUrl: 'githubUrl'});
+});
+
+test('initAPIVariables should postMessage defaults if values aren\'t provided', t => {
+  let addEventListener = () => {};
+  let postMessage = (result) => {
+    let [fnName, fnData] = result;
+    let {postData} = JSON.parse(fnData);
+    let { accessToken, apiUrl, githubUrl } = postData;
+    t.is(fnName, 'initAPIVariables');
+    t.is(accessToken, '');
+    t.is(apiUrl, 'https://api.github.com');
+    t.is(githubUrl, 'https://github.com/');
+  };
+  let worker = getWorker(addEventListener, postMessage);
+
+  registerWorker(worker);
+  initAPIVariables({});
+});
+
+test('addRepoForm should trigger addRepo on submissions', t => {
+  let expectedRepos = ['user/repo3', 'user/repo2', 'user/repo1'];
+
+  function postMessage(message) {
+    if (!message) {
+      message = [];
+    }
+
+    let fnName = message[0];
+    let postData = message[1];
+
+    if (fnName === 'addRepo') {
+      let fnData = JSON.parse(postData);
+      if (expectedRepos) {
+        t.is(expectedRepos[expectedRepos.length -1], fnData.postData);
+        expectedRepos.pop();
+      }
+      if (!expectedRepos.length) {
+        return t.pass();
+      }
+    }
+
+    if (this.fns.message) {
+      this.fns.message({
+        data: [fnName, postData]
+      });
+    }
+  }
+  function addEventListener(type, fn) {
+    this.fns[type] = fn;
+  }
+
+  let worker = getWorker(addEventListener, postMessage);
+  registerWorker(worker);
+
+  let {addRepoForm, addRepoInput} = loadAddRepoListeners();
+
+  ['user/repo1', 'user/repo2', 'user/repo3'].forEach(repo => {
+    addRepoInput.value = repo;
+    let event = new Event('submit');
+    addRepoForm.dispatchEvent(event);
+    t.is(addRepoInput.value, '');
+  });
+});
+
+test('addRepoInput input event should clean up the input', t => {
+
+  let {addRepoInput} = loadAddRepoListeners();
+
+  ['https://github.com/user/repo1', 'https://github.com/user/repo1/issues', 'user/repo1/', 'user/repo1/issues', 'user/repo1']
+    .forEach(inputVal => {
+    addRepoInput.value = inputVal;
+    let event = new Event('input');
+    addRepoInput.dispatchEvent(event);
+    t.is(addRepoInput.value, 'user/repo1');
+  });
+});
+
+test('syncAll should trigger getAllRepoDetails', t => {
+
+  function postMessage(message) {
+    let fnName = message[0];
+
+    if (fnName === 'getAllRepoDetails') {
+      return t.pass();
+    }
+    t.fail();
+  }
+  function addEventListener(type, fn) {
+    this.fns[type] = fn;
+  }
+
+  let worker = getWorker(addEventListener, postMessage);
+  registerWorker(worker);
+
+  let {syncAll} = loadAddRepoListeners();
+
+  syncAll.click();
+})
+
+test('click authStatus should open a window that postMessages back', t => {
+
+  return new Promise(function(resolve) {
+    let authStatus;
+    let fns = {};
+    global.window.addEventListener = (type, fn) => {
+      fns[type] = fn;
+    };
+
+    global.window.open = () => {
+      return {
+        postMessage() {
+          let event = {
+            origin: global.window.location.origin,
+            data: 'super_secret_token',
+            source: {
+              close() {
+                t.not(authStatus, global.document.getElementById('authStatus'));
+                t.pass();
+                resolve();
+              }
+            }
+          };
+          fns.message(event);
+        }
+      }
+    };
+
+    function postMessage(message) {
+      let fnName = message[0];
+
+      if (fnName === 'setAccessToken') {
+        return t.pass();
+      }
+      t.fail();
+    }
+    function addEventListener(type, fn) {
+      this.fns[type] = fn;
+    }
+
+    let worker = getWorker(addEventListener, postMessage);
+    registerWorker(worker);
+
+    let listenerElements = loadAddRepoListeners();
+    authStatus = listenerElements.authStatus;
+
+    authStatus.click();
+  });
+});
+
+test('click authStatus should NOT handle a postMessages from a different origin', t => {
+
+  return new Promise(function(resolve) {
+    let authStatus;
+    let fns = {};
+    global.window.addEventListener = (type, fn) => {
+      fns[type] = fn;
+    };
+
+    global.window.open = () => {
+      return {
+        postMessage() {
+          let event = {
+            origin: 'asdf',
+            data: 'super_secret_token',
+            source: {
+              close() {
+                t.fail();
+              }
+            }
+          };
+          fns.message(event);
+          setTimeout(resolve, 50);
+        }
+      }
+    };
+
+    function postMessage(message) {}
+    function addEventListener(type, fn) {}
+
+    let worker = getWorker(addEventListener, postMessage);
+    registerWorker(worker);
+
+    let listenerElements = loadAddRepoListeners();
+    authStatus = listenerElements.authStatus;
+
+    authStatus.click();
+  });
+});
+
+test('app should not explode if authStatus isn\'t on the DOM', t => {
+  global.document = require('jsdom').jsdom(`
+    <div id="octoshelf">
+    <section id="addSection" class="app-prompt">
+        <form id="addRepoForm" class="bubble">
+            <img class="octoshelf-icon" src="/images/octoshelf-icon.png" alt="OctoShelf, a GitHub powered pull request manager" />
+            <div class="addRepoInput-wrapper">
+                <div class="addRepoInput-prefix">githubUrl</div>
+                <input type="text" id="addRepoInput" class="addRepoInput-input" placeholder="Repository Url" />
+            </div>
+            <div>
+                <a href="#" id="syncAll" class="octicon octicon-sync"></a>
+            </div>
+        </form>
+    </section>
+    </div>
+   `);
+  delete require.cache[require.resolve('../public/scripts/addRepo')];
+  let addRepo = require('../public/scripts/addRepo');
+  addRepo.loadAddRepoListeners();
+  t.pass();
+});
+
+test('setInitialFetch should call appropriate addRepos', t => {
+
+  let expectedRepos = ['user/repo3', 'user/repo2', 'user/repo1'];
+
+  function postMessage(message) {
+    if (!message) {
+      message = [];
+    }
+
+    let fnName = message[0];
+    let postData = message[1];
+
+    if (fnName === 'addRepo') {
+      let fnData = JSON.parse(postData);
+      if (expectedRepos) {
+        t.is(expectedRepos[expectedRepos.length -1], fnData.postData);
+        expectedRepos.pop();
+      }
+      if (!expectedRepos.length) {
+        return t.pass();
+      }
+    }
+
+    if (this.fns.message) {
+      this.fns.message({
+        data: [fnName, postData]
+      });
+    }
+  }
+  function addEventListener(type, fn) {
+    this.fns[type] = fn;
+  }
+
+  let worker = getWorker(addEventListener, postMessage);
+
+  registerWorker(worker);
+
+  let repoStateManager = {
+    fetch(addRepo) {
+      addRepo('user/repo1');
+    }
+  };
+  let sharedRepos = ['user/repo2', 'user/repo3'];
+  setInitialFetch(repoStateManager, sharedRepos);
+  worker.postMessage(['apiInitialized', '{}']);
+});

--- a/tests/conductor.js
+++ b/tests/conductor.js
@@ -8,6 +8,8 @@ let conductor;
 let registerWorker, registerWorkerEventHandles, workerPostMessage;
 
 test.beforeEach(t => {
+  let {shh} = require('../public/scripts/utilities');
+  shh();
   delete require.cache[require.resolve('../public/scripts/conductor')];
   conductor = require('../public/scripts/conductor');
   registerWorker = conductor.registerWorker;

--- a/tests/octoshelf.js
+++ b/tests/octoshelf.js
@@ -5,6 +5,6 @@ import './helpers/setup-browser-env.js';
 
 import Octoshelf from '../public/scripts/octoshelf';
 
-test('test', t => {
+test.skip('Octoshelf tests need to be written', t => {
   t.pass();
 });

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -3,7 +3,7 @@ import 'babel-register';
 import test from 'ava';
 import './helpers/setup-browser-env.js';
 
-import {log, notify} from '../public/scripts/utiltities';
+import {log, notify} from '../public/scripts/utilities';
 
 const consoleLog = console.log;
 const consoleGroup = console.group;

--- a/views/auth.ejs
+++ b/views/auth.ejs
@@ -5,10 +5,10 @@
     <script>
         window.addEventListener('message',function(event) {
             let origin = event.origin;
-            if (event.origin !== '<%= origin %>') {
+            if (origin !== window.location.origin) {
                 return;
             }
-            event.source.postMessage('<%= accessToken %>', event.origin);
+            event.source.postMessage('<%= accessToken %>', origin);
         },false);
     </script>
 </head>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -108,8 +108,7 @@
 <script>
     var hydratedConfig = {
         accessToken: '<%= accessToken %>',
-        sharedRepos: '<%= sharedRepos %>',
-        origin: '<%= origin %>'
+        sharedRepos: '<%= sharedRepos %>'
     }
 </script>
 <script src="/app.js"></script>


### PR DESCRIPTION
`Octoshelf.js` had too many responsibilities, and more are on its way.
To simplify the code, I pulled out everything related to adding repos,
and instead am using an `AddRepo.js` module.  I wrote a bunch of tests,
and improved some of the code.

Improvements include cleaner parsing of input values.  If the user
enters or copy/pastes `http://github.com/user/repo/issues`, it will
get converted to `user/repo`.

I added a `shh()` function to the `utilities` function, since console.log
was beginning to get in the way of debugging.

I renamed `public/scripts/utiltities.js -> public/scripts/utilities.js`
... whups, typos :/.

I also took out the chunk of code that passed around an app origin. Really
that can just be derived from the browser, so theres no need to maintain it.