### PR TITLE
Adding Navi, cleaning tests, adding `active` classes for buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,12 @@
     "whatwg-fetch": "^1.0.0",
     "worker-loader": "^0.7.0"
   },
+  "ava" : {
+    "require": [
+      "babel-register",
+      "./tests/helpers/setup-browser-env.js"
+    ]
+  },
   "nyc": {
     "exclude": [
       "tests",

--- a/public/scripts/actionPanel.js
+++ b/public/scripts/actionPanel.js
@@ -41,8 +41,10 @@ export function loadActionPanelListeners() {
     let {value} = event.target;
     let delay = Number(value);
     if (delay) {
+      refreshRateToggle.classList.add('active');
       return postMessageToWorker('startRefreshing', delay);
     }
+    refreshRateToggle.classList.remove('active');
     return postMessageToWorker('stopRefreshing', '');
   });
   requestNotifications.addEventListener('click', function(event) {
@@ -66,6 +68,7 @@ export function loadActionPanelListeners() {
   });
   refreshRateToggle.addEventListener('click', function(event) {
     event.preventDefault();
+    shareToggle.classList.remove('active');
     shareContent.classList.remove('toggle');
     refreshContent.classList.toggle('toggle');
   });
@@ -74,9 +77,15 @@ export function loadActionPanelListeners() {
     updateShareLink();
     refreshContent.classList.remove('toggle');
     shareContent.classList.toggle('toggle');
+    shareToggle.classList.toggle('active');
   });
 
   postMessageToWorker('startRefreshing', startingRefreshRate);
+  refreshRateToggle.classList.add('active');
+
+  if (Notification && Notification.permission === 'granted') {
+    requestNotifications.classList.add('active');
+  }
 
   return {
     appElement,

--- a/public/scripts/navi.js
+++ b/public/scripts/navi.js
@@ -1,0 +1,58 @@
+/**
+ * HEY!  HEY LISTEN!
+ * Navi is responsible for sending out web and mobile notifications
+ */
+
+import {registerWorkerEventHandles} from './conductor';
+
+/**
+ * If Notifications are permitted, send out a notification.
+ * @param {String} title - notification title
+ * @param {String} body - notification body
+ * @param {Function} onclick - notification onclick
+ * @param {Number} duration - notification duration before it self-closes (defaults to 5 seconds)
+ * @return {Notification|null} - either return the newly created notification, or return null
+ */
+export function sendWebNotification(title, body, onclick = () => {}, duration = 5000) {
+  let {permission} = Notification;
+  let permissionMap = {
+    granted() {
+      let notification = new Notification(title, {
+        body,
+        icon: '/images/octoshelf-icon-dark.jpg'
+      });
+      notification.onclick = event => {
+        onclick(event);
+        notification.close();
+      };
+      setTimeout(notification.close.bind(notification), duration);
+      return notification;
+    },
+    // no-op
+    denied() {}
+  };
+
+  return permissionMap[permission] ? permissionMap[permission]() : null;
+}
+
+/**
+ * Attempt to send a notification with a window.open onclick handler
+ * @param {String} title - notification title
+ * @param {String} body - notification body
+ * @param {String} url - notification url
+ * @param {Number} duration - duration of time notification should live
+ * @return {Notification|null} - return either a newly created notification, or null
+ */
+export function sendLinkNotification({title, body, url, duration}) {
+  if (!url) {
+    return null;
+  }
+  return sendWebNotification(title, body, event => {
+    event.preventDefault();
+    window.open(url, '_blank');
+  }, duration);
+}
+
+registerWorkerEventHandles('Notifications', {
+  sendLinkNotification
+});

--- a/public/scripts/octo.worker.js
+++ b/public/scripts/octo.worker.js
@@ -66,8 +66,8 @@ function setAccessToken(newAccessToken) {
  * @param {Object} PullRequest - Pull Request Object from the github api
  * @return {Object} simplePullRequest - smaller, cleaner pull request object
  */
-function simplifyPR({id, title, html_url: url}) {
-  return {id, title, url};
+function simplifyPR({id, body, title, html_url: url}) {
+  return {id, body, title, url};
 }
 
 /**
@@ -246,14 +246,12 @@ function getNewPullRequests(fetchedResults, previousResults) {
  */
 function sendNewPullRequestNotification(pullRequests, isPageVisible) {
   if (!isPageVisible) {
-    pullRequests = pullRequests.filter(pr => pr.url);
-    let size = pullRequests.length;
-    let requestWord = size > 1 ? 'requests' : 'request';
-    let title = `[OctoShelf] : ${size} new pull ${requestWord}`;
-    let body = pullRequests.map(pr => {
-      return '• ' + pr.url.replace(githubUrl, '');
-    }).join('\n');
-    sendNotification(title, body);
+    pullRequests.filter(pr => pr.url).forEach(pr => {
+      let title = `[OctoShelf] New PR: ${pr.title}`;
+      let body = pr.body;
+      let url = pr.url;
+      parsedPostMessage('sendLinkNotification', {title, body, url});
+    });
   }
 }
 
@@ -337,31 +335,6 @@ function log() {
  */
 function parsedPostMessage(messageType, postData) {
   self.postMessage([messageType, JSON.stringify({postData})]);
-}
-
-/**
- * If Notifications are permitted, send out a notification.
- * @param {String} notifyTitle - notification title
- * @param {String} body - notification body
- */
-function sendNotification(notifyTitle, body) {
-  let {permission} = Notification;
-  let permissionMap = {
-    granted() {
-      let notification = new Notification(notifyTitle, {
-        body,
-        icon: '/images/octoshelf-icon-dark.jpg'
-      });
-      setTimeout(notification.close.bind(notification), 5000);
-    },
-    denied() {
-      // no-op
-    }
-  };
-
-  if (permissionMap[permission]) {
-    permissionMap[permission]();
-  }
 }
 
 /**

--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -4,6 +4,7 @@ import {notify} from './utilities';
 import {loadActionPanelListeners, updateShareLink} from './actionPanel';
 import {loadAnimations, updateRotations} from './animations';
 import {loadAddRepoListeners, initAPIVariables, setInitialFetch} from './addRepo';
+import './navi';
 
 import {workerPostMessage, registerWorkerEventHandles} from './conductor';
 const postMessageToWorker = workerPostMessage('OctoShelf');

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -215,6 +215,10 @@ a{ color: #fff}
 .infoPanel-actions {border-left: 1px solid #fff;padding-left: 0.5rem;margin-left: 0.5rem;position: relative}
 .infoPanel-action {font-size: 1.2em;margin-left: 1rem;}
 
+.infoPanel-action.active {
+    color: #46FF46;
+}
+
 
 .share-content {
     background: #fff;
@@ -320,6 +324,7 @@ a{ color: #fff}
 .octoInline .bubble .repositoryInner {transform: none !important;height: initial;}
 .octoInline .repo-title {margin-right: 1rem;width: inherit;}
 .octoInline .repository:after {display: none;}
+.octoInline + .infoPanel .toggleViewType {color: #46FF46;}
 
 @media (max-width: 700px) {
     .infoPanel {padding:  1rem 0.5rem}

--- a/tests/actionPanel.js
+++ b/tests/actionPanel.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 import {registerWorker} from '../public/scripts/conductor';
 

--- a/tests/addRepo.js
+++ b/tests/addRepo.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 import {registerWorker} from '../public/scripts/conductor';
 

--- a/tests/conductor.js
+++ b/tests/conductor.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 let worker;
 let conductor;

--- a/tests/helpers/setup-browser-env.js
+++ b/tests/helpers/setup-browser-env.js
@@ -4,6 +4,9 @@ global.navigator = window.navigator;
 global.Promise = window.Promise;
 global.Event = window.Event;
 global.fetch = () => {};
+
+// Dummy Browser Apis
+global.Notification = () => {close()  };
 global.localStorage = {
   getItem(){},
   setItem(){}

--- a/tests/navi.js
+++ b/tests/navi.js
@@ -1,0 +1,98 @@
+
+import test from 'ava';
+
+import {sendLinkNotification, sendWebNotification} from '../public/scripts/navi';
+
+test('sendLinkNotification should emit a notification that self-closes', t => {
+
+  return new Promise(function(resolve) {
+    let closeDuration = 1000;
+    let isClosed = false;
+    let Notification = (notifyTitle, {body, icon}) => {
+      t.is(notifyTitle, 'notifyTitle');
+      t.is(body, 'notifyBody');
+      t.is(icon, '/images/octoshelf-icon-dark.jpg');
+      return {
+        close: () => {
+          isClosed = true;
+          t.pass();
+        }
+      }
+    };
+    Notification.permission = 'granted';
+    global.Notification = Notification;
+    sendLinkNotification({title: 'notifyTitle', body: 'notifyBody', url: 'notifyUrl', duration: closeDuration});
+
+    setTimeout(() => {
+      t.is(isClosed, true);
+      resolve();
+    }, closeDuration);
+  });
+});
+
+test('sendLinkNotification should trigger a window.open when clicked', t => {
+
+  let closeDuration = 1000;
+  let Notification = () => {
+    return {
+      close: () => {}
+    }
+  };
+  Notification.permission = 'granted';
+  global.Notification = Notification;
+  global.window.open = (url, windowName) => {
+    t.is(url, 'notifyUrl');
+    t.is(windowName, '_blank');
+    t.pass();
+  };
+  let myNotification = sendLinkNotification({title: 'notifyTitle', body: 'notifyBody', url: 'notifyUrl', duration: closeDuration});
+
+  let fakeEvent = {
+    preventDefault(){}
+  };
+  myNotification.onclick(fakeEvent);
+});
+
+test('sendLinkNotification should not create a notification without a url', t => {
+
+  let Notification = () => {
+    t.fail();
+  };
+  Notification.permission = 'granted';
+  global.Notification = Notification;
+  sendLinkNotification({title: 'notifyTitle', body: 'notifyBody', url: '', duration: 1000});
+});
+
+test('sendLinkNotification should not create a notification if permission is denied', t => {
+
+  let Notification = () => {
+    t.fail();
+  };
+  Notification.permission = 'denied';
+  global.Notification = Notification;
+  sendLinkNotification({title: 'notifyTitle', body: 'notifyBody', url: 'notifyUrl', duration: 1000});
+});
+
+test('sendLinkNotification should not create a notification with foreign permissions', t => {
+
+  let Notification = () => {
+    t.fail();
+  };
+  Notification.permission = 'asdf';
+  global.Notification = Notification;
+  sendLinkNotification({title: 'notifyTitle', body: 'notifyBody', url: 'notifyUrl', duration: 1000});
+});
+
+test('sendWebNotification should not blow up without a click handler or duration', t => {
+  let Notification = () => {
+    return {
+      close: () => {}
+    }
+  };
+  Notification.permission = 'granted';
+  global.Notification = Notification;
+  let myNotification = sendWebNotification('notifyTitle', 'notifyBody');
+  t.not(myNotification.onclick, null);
+  myNotification.onclick();
+  t.pass();
+});

--- a/tests/octoshelf.js
+++ b/tests/octoshelf.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 import Octoshelf from '../public/scripts/octoshelf';
 

--- a/tests/peppermint.js
+++ b/tests/peppermint.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 import Peppermint from '../public/scripts/peppermint';
 

--- a/tests/utilities.js
+++ b/tests/utilities.js
@@ -1,7 +1,5 @@
 
-import 'babel-register';
 import test from 'ava';
-import './helpers/setup-browser-env.js';
 
 import {log, notify} from '../public/scripts/utilities';
 


### PR DESCRIPTION
**Adding Navi** - a small module that sends notifications.
Before the web worker use to handle sending notifications. After
toying aronud with it and trying to make updates to the notifications,
I found out that the web worker is not the best place for the notification.

For one, `window.open` is invalid within a web worker (since it has
a limited scope of document and window.) But more importantly, the
web worker's responsibility should really just be to maintain state.
Adding more work complicates the module, so... taking the notification
stuff out feels like a good call.

**Cleaning tests** - auto require babel-register and browser-setup.

**Active class** - got feedback from @ethangodt that a visual indicator
of "active" would be helpful, and hes totally right.