### PR TITLE
Adding Repo Section

### DIFF
--- a/public/entry/app.js
+++ b/public/entry/app.js
@@ -3,7 +3,6 @@ import OctoShelf from '../scripts/octoshelf.js';
 import config from '../../config/config.json';
 
 import {registerWorker} from '../scripts/conductor.js';
-
 const OctoWorker = require("../scripts/octo.worker.js");
 registerWorker(new OctoWorker());
 

--- a/public/scripts/actionPanel.js
+++ b/public/scripts/actionPanel.js
@@ -36,7 +36,7 @@ function requestNotificationPermission() {
  * Load the App event listeners
  * @return {Object} elements we binded listeners to. (helpful for testing)
  */
-export function loadActionPanelListeners() {
+export function loadActionPanel() {
   refreshRateOptions.addEventListener('change', function(event) {
     let {value} = event.target;
     let delay = Number(value);
@@ -119,11 +119,11 @@ export function updateShareLink(origin = window.location.origin) {
   let repoSection = document.getElementById('repoSection');
   let shareUrl = document.getElementById('shareUrl');
 
-  let child = repoSection.firstChild;
+  let child = repoSection.firstElementChild;
   let urls = [];
   while (child) {
     urls.push(child.getAttribute('data-url'));
-    child = child.nextSibling;
+    child = child.nextElementSibling;
   }
   let url = origin;
   if (urls.length) {

--- a/public/scripts/animations.js
+++ b/public/scripts/animations.js
@@ -5,6 +5,7 @@
  * These functions only provide visual feedback, so excluded from unit tests.
  */
 
+const appElement = document.getElementById('octoshelf');
 const stylesheetHelper = document.createElement("style");
 const appBackground = document.getElementById('appBackground');
 const repoSection = document.getElementById('repoSection');
@@ -17,7 +18,7 @@ let centerDistance = 0;
  * Update Bubble Styles by injecting new css rules
  * @param {Element} appElement - core OctoShelf app element
  */
-function updateBubbleStyles(appElement) {
+function updateBubbleStyles() {
   let {innerHeight, innerWidth} = window;
   let modifiedHeight = innerHeight - 40;
   let bubbleModify = bubbleSize / 2;
@@ -124,7 +125,7 @@ export function updateRotations() {
  * Load initial animations and any animation specific event handlers
  * @param {Element} appElement - core OctoShelf element
  */
-export function loadAnimations(appElement) {
+export function loadAnimations() {
   document.head.appendChild(stylesheetHelper);
   lazyLoadBackground();
   updateBubbleStyles(appElement);

--- a/public/scripts/localRepoState.js
+++ b/public/scripts/localRepoState.js
@@ -1,0 +1,46 @@
+/**
+ * RepoStateManager - Abstracts away persisting repository urls and CRUDs.
+ * Should we decide to change to a cookie, session storage, etc, we can
+ * simply update it here, and not have to worry about a stray localStorage
+ * elsewhere.
+ */
+
+// An array of repository urls
+let repositories = [];
+  // A set of unique repository urls, used to prevent duplicates being added
+let uniqueRepos = new Set();
+
+/**
+ * Add a repo url to local state
+ * @param {String} url - url to add
+ */
+export function addLocalRepo(url) {
+  if (!uniqueRepos.has(url)) {
+    uniqueRepos.add(url);
+    repositories.push(url);
+    localStorage.setItem('repositories', JSON.stringify(repositories));
+  }
+}
+
+/**
+ * Remove a repo url from local state
+ * @param {String} url - url to remove
+ */
+export function removeLocalRepo(url) {
+  repositories = repositories.filter(repoUrl => repoUrl !== url);
+  uniqueRepos.delete(url);
+  localStorage.setItem('repositories', JSON.stringify(repositories));
+}
+
+/**
+ * Get all the repos from local storage
+ * @return {Array} repositories - array of the repository urls
+ */
+export function getLocalRepos() {
+  let repoString = localStorage.getItem('repositories') || '[]';
+  repositories = JSON.parse(repoString);
+  repositories.forEach(url => {
+    uniqueRepos.add(url);
+  });
+  return repositories;
+}

--- a/public/scripts/octo.worker.js
+++ b/public/scripts/octo.worker.js
@@ -176,13 +176,13 @@ function fetchRepo(repoUrl) {
  * @return {Promise.<T>} RepoDetails - repo details
  */
 function getRepoDetails(repository) {
-  let {id, url, fetchedDetails} = repository;
+  let {url, fetchedDetails} = repository;
   let repoUrl = url.replace(githubUrl, '');
   let repoStillOnDom = true;
 
   // If we already got the repository details, lets only fetch pull requests
   if (fetchedDetails) {
-    parsedPostMessage('toggleLoadingRepository', [id, url, true]);
+    parsedPostMessage('toggleLoadingRepository', [url, true]);
     return fetchRepoPulls(repoUrl)
       .then(prs => {
         repository.prs = prs.map(simplifyPR);
@@ -192,7 +192,7 @@ function getRepoDetails(repository) {
       })
       .then(() => {
         parsedPostMessage('updateRepository', repository);
-        parsedPostMessage('toggleLoadingRepository', [id, url, false]);
+        parsedPostMessage('toggleLoadingRepository', [url, false]);
         return repository;
       });
   }
@@ -217,7 +217,7 @@ function getRepoDetails(repository) {
     .then(() => {
       if (repoStillOnDom) {
         parsedPostMessage('updateRepository', repository);
-        parsedPostMessage('toggleLoadingRepository', [id, url, false]);
+        parsedPostMessage('toggleLoadingRepository', [url, false]);
       }
       return Promise.resolve(repository);
     });

--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -1,307 +1,30 @@
 'use strict';
 
-import {notify} from './utilities';
-import {loadActionPanelListeners, updateShareLink} from './actionPanel';
-import {loadAnimations, updateRotations} from './animations';
-import {loadAddRepoListeners, initAPIVariables, setInitialFetch} from './addRepo';
+import {log, notify} from './utilities';
+import {loadActionPanel} from './actionPanel';
+import {loadAnimations} from './animations';
+import {loadAddRepoSection} from './addRepo';
+import {loadRepoSection} from './repoSection';
 import './navi';
 
 import {workerPostMessage, registerWorkerEventHandles} from './conductor';
 const postMessageToWorker = workerPostMessage('OctoShelf');
 
-const appElement = document.getElementById('octoshelf');
-const repoSection = document.getElementById('repoSection');
-
-const prResizeThreshold = 8;
-let isPageVisible = true;
-let newPRQueue = [];
-
+let accessToken = '';
+let apiUrl = 'https://api.github.com';
 let githubUrl = 'https://github.com/';
+
 let sharedReposString = '';
 let sharedRepos = [];
 
 /**
- * RepoStateManager - Abstracts away persisting repository urls and CRUDs.
- * Should we decide to change to a cookie, session storage, etc, we can
- * simply update it here, and not have to worry about a stray localStorage
- * elsewhere.
+ * Initialize the app with a bunch of variables defining github endpoints
+ * @param {Object} apiVariables -  Object that defines several github api values
  */
-const repoStateManager = {
-  // An array of repository urls
-  repositories: [],
-  // A set of unique repository urls, used to prevent duplicates being added
-  uniqueRepos: new Set(),
-  add(url) {
-    if (!this.uniqueRepos.has(url)) {
-      this.repositories.push(url);
-      localStorage.setItem('repositories', JSON.stringify(this.repositories));
-    }
-  },
-  remove(url) {
-    this.repositories = this.repositories.filter(repoUrl => repoUrl !== url);
-    this.uniqueRepos.delete(url);
-    localStorage.setItem('repositories', JSON.stringify(this.repositories));
-  },
-  fetch(addRepository) {
-    let repoString = localStorage.getItem('repositories') || '[]';
-    this.repositories = JSON.parse(repoString);
-    this.repositories.forEach(url => {
-      this.uniqueRepos.add(url);
-      addRepository(url);
-    });
-  }
-};
-
-/**
- * Load Event Listeners specific to OctoShelf
- */
-function loadAppEventListeners() {
-  repoSection.addEventListener('click', function(event) {
-    let {action, url} = event.target && event.target.dataset;
-    let actionMap = {
-      refresh() {
-        postMessageToWorker('getRepoDetailsByUrl', url);
-      },
-      remove() {
-        postMessageToWorker('removeRepo', url);
-      }
-    };
-
-    if (actionMap[action]) {
-      event.preventDefault();
-      actionMap[action]();
-    }
-  });
-  window.addEventListener("visibilitychange", function() {
-    isPageVisible = document.visibilityState !== 'hidden';
-    postMessageToWorker('pageVisibilityChanged', isPageVisible);
-    removeNewPullRequestAnimations();
-  });
-}
-
-/**
- * Toggle the loading class (which drops opacity) on repositories
- * @param {String|Number} id - if of the element we are updating
- * @param {String} url - url of the element we are updating
- * @param {Boolean} isLoading - toggle showing loading state or not
- */
-function toggleLoadingRepository([id, url, isLoading]) {
-  let article = document.getElementById(id) ||
-    document.querySelector(`[data-url="${url}"]`);
-
-  if (!article) {
-    notify('Something went wrong');
-    return;
-  }
-
-  if (isLoading) {
-    article.classList.add('loading');
-    return;
-  }
-  article.classList.remove('loading');
-}
-
-/**
- * Draw a simple placeholder repo into the repoSection.
- * Later we will fill up the drawn element with more data.
- * @param {Object} Repo - Repo Object
- * @return {Element} article - placeholder element
- */
-function drawPlaceholderRepo({url}) {
-  let lastRepo = repoSection.lastElementChild;
-
-  let article = document.createElement('article');
-  article.setAttribute('class', 'bubble repository loading');
-  article.setAttribute('data-url', url);
-
-  let repositoryInner = document.createElement('div');
-  repositoryInner.setAttribute('class', 'repositoryInner');
-
-  let header = document.createElement('header');
-  let title = document.createElement('span');
-  title.setAttribute('class', 'repo-title');
-
-  let actionsElement = document.createElement('div');
-  let repoLink = document.createElement('a');
-  let sync = document.createElement('a');
-  let trash = document.createElement('a');
-  let href = `${githubUrl}${url}`;
-  let actions = [
-    {elem: repoLink, action: '', className: 'repo', href},
-    {elem: sync, action: 'refresh', className: 'sync'},
-    {elem: trash, action: 'remove', className: 'x'}
-  ];
-  actions.forEach(({elem, action, className, href}) => {
-    elem.setAttribute('href', href || '#');
-    elem.setAttribute('target', 'blank');
-    elem.setAttribute('data-action', action);
-    elem.setAttribute('class', `octicon octicon-${className} action`);
-    elem.setAttribute('data-url', url);
-  });
-
-  let prListItems = document.createElement('ul');
-  prListItems.setAttribute('class', 'prList');
-
-  if (lastRepo) {
-    let firstChild = lastRepo.firstElementChild;
-    article.style.cssText = lastRepo.getAttribute('style');
-    repositoryInner.style.cssText = firstChild.getAttribute('style');
-  }
-
-  article
-    .appendChild(repositoryInner)
-    .appendChild(header)
-    .appendChild(title)
-    .appendChild(document.createTextNode(url));
-
-  repositoryInner.appendChild(prListItems);
-  actions.forEach(({elem}) => actionsElement.appendChild(elem));
-  repositoryInner.appendChild(actionsElement);
-
-  // The Repo is built, lets append it!
-  repoSection.appendChild(article);
-  repoStateManager.add(url);
-  updateShareLink();
-
-  // Now that we've added a placeholder, lets spin to win!
-  // The 100ms delay adds a cool animation effect
-  setTimeout(updateRotations, 100);
-
-  return article;
-}
-
-/**
- * Update the repository article element with any changes
- * @param {Object} repository - Repository Details
- * @param {Element} placeholder - Placeholder Element
- */
-function updateRepository(repository) {
-  let {id, name, url, fullName, placeholderUpdated, prs} = repository;
-  let article = document.getElementById(id) ||
-    document.querySelector(`[data-url="${url}"]`);
-
-  if (!article) {
-    article = drawPlaceholderRepo(repository);
-  }
-
-  // If we have not had the opportunity to the DOM earlier, do it now.
-  if (!placeholderUpdated) {
-    // If there wasn't an id before, set it now
-    if (!article.id) {
-      article.setAttribute('id', id);
-    }
-
-    let actions = article.querySelectorAll('[data-action]');
-    let actionSize = actions.length;
-    for (let index = 0; index < actionSize; index++) {
-      let action = actions[index];
-      action.setAttribute('data-id', id);
-    }
-
-    // Swap out the title with a better one
-    let repoTitle = article.querySelector('.repo-title');
-    repoTitle.innerText = name;
-    repoTitle.setAttribute('title', fullName);
-
-    repository.placeholderUpdated = true;
-  }
-
-  let prListItems = article.querySelector('.prList');
-  let pullRequestFragment = document.createDocumentFragment();
-
-  if (prs.length > prResizeThreshold) {
-    prListItems.classList.add('lotsOfPRs');
-  } else {
-    prListItems.classList.remove('lotsOfPRs');
-  }
-
-  prs.forEach(({id, title, url}) => {
-    let prListItem = document.getElementById(id);
-    let prMoreInfo;
-    if (prListItem) {
-      prMoreInfo = prListItem.querySelector('.prMoreInfo');
-      prMoreInfo.innerText = title;
-      return pullRequestFragment.appendChild(prListItem);
-    }
-
-    prListItem = document.createElement('li');
-    let prLink = document.createElement('a');
-    prMoreInfo = document.createElement('span');
-
-    prListItem.setAttribute('id', id);
-
-    prLink.setAttribute('href', url);
-    prLink.setAttribute('target', '_blank');
-    prLink.setAttribute('class', 'prLink octicon octicon-git-pull-request');
-
-    prListItem.classList.add('prListItem');
-    prMoreInfo.classList.add('prMoreInfo');
-
-    pullRequestFragment
-      .appendChild(prListItem)
-      .appendChild(prLink)
-      .appendChild(prMoreInfo)
-      .appendChild(document.createTextNode(title));
-  });
-
-  prListItems.innerHTML = '';
-  prListItems.appendChild(pullRequestFragment);
-
-  article.classList.remove('loading');
-}
-
-/**
- * Remove a repository from the DOM
- * @param {String} url - repositories have a data-url="" to target from
- */
-function removeRepository(url) {
-  let article = document.querySelector(`[data-url="${url}"]`);
-  if (!article) {
-    notify('Something went wrong');
-    return;
-  }
-  article.parentNode.removeChild(article);
-  repoStateManager.remove(url);
-  updateShareLink();
-
-  setTimeout(updateRotations, 100);
-}
-
-/**
- * Given an array of pull request ids, add a "newPullRequest" class and remove it
- * @param {Array} ids - array of pull request ids
- */
-function animateNewPullRequests(ids) {
-  ids.forEach(id => {
-    let element = document.getElementById(id);
-    if (!element) {
-      return;
-    }
-    element.classList.add('newPullRequest');
-  });
-  newPRQueue.push(...ids);
-  removeNewPullRequestAnimations();
-}
-
-/**
- * Remove the "highlight" style from newly added pull requests...
- * only when the user is looking at the page.  Otherwise, we
- * continue queing them up for later.
- */
-function removeNewPullRequestAnimations() {
-  if (!isPageVisible) {
-    return;
-  }
-  newPRQueue.forEach(id => {
-    let element = document.getElementById(id);
-    if (!element) {
-      return;
-    }
-    setTimeout(() => {
-      element.classList.remove('newPullRequest');
-    }, 1000);
-  });
-  newPRQueue = [];
+function initAPIVariables(apiVariables) {
+  githubUrl = apiVariables.githubUrl;
+  sharedRepos = apiVariables.sharedRepos;
+  postMessageToWorker('initAPIVariables', apiVariables);
 }
 
 /**
@@ -314,26 +37,24 @@ function removeNewPullRequestAnimations() {
  */
 export default function OctoShelf(options) {
   githubUrl = options.githubUrl || githubUrl;
+  accessToken = options.accessToken || accessToken;
+  apiUrl = options.apiUrl || apiUrl;
+
   sharedReposString = options.sharedRepos || sharedReposString;
   sharedRepos = sharedReposString.split(',');
+
+  let apiOptions = {accessToken, apiUrl, githubUrl, sharedRepos};
 
   /**
    * Initialize the app!
    */
-  setInitialFetch(repoStateManager, sharedRepos);
-  initAPIVariables(options);
+  initAPIVariables(apiOptions);
 
   // Load event listeners
-  loadAnimations(appElement);
-  loadActionPanelListeners();
-  loadAppEventListeners();
-  loadAddRepoListeners();
+  loadAnimations();
+  loadActionPanel();
+  loadAddRepoSection(apiOptions);
+  loadRepoSection(apiOptions);
 }
 
-registerWorkerEventHandles('OctoShelf', {
-  drawPlaceholderRepo,
-  animateNewPullRequests,
-  updateRepository,
-  removeRepository,
-  toggleLoadingRepository
-});
+registerWorkerEventHandles('OctoShelf', {log, notify});

--- a/public/scripts/repoSection.js
+++ b/public/scripts/repoSection.js
@@ -1,0 +1,275 @@
+
+import {notify} from './utilities';
+import {addLocalRepo, removeLocalRepo} from './localRepoState';
+import {updateShareLink} from './actionPanel';
+import {updateRotations} from './animations';
+import {workerPostMessage, registerWorkerEventHandles} from './conductor';
+const postMessageToWorker = workerPostMessage('RepoSection');
+
+const repoSection = document.getElementById('repoSection');
+
+const prResizeThreshold = 8;
+let newPRQueue = [];
+let isPageVisible = true;
+let githubUrl = '';
+
+/**
+ * Load Event Listeners specific to OctoShelf
+ * @param {Object} apiOptions - api options
+ */
+export function loadRepoSection(apiOptions) {
+  githubUrl = apiOptions.githubUrl;
+  repoSection.addEventListener('click', function(event) {
+    let {action, url} = event.target && event.target.dataset;
+    let actionMap = {
+      refresh() {
+        postMessageToWorker('getRepoDetailsByUrl', url);
+      },
+      remove() {
+        postMessageToWorker('removeRepo', url);
+      }
+    };
+
+    if (actionMap[action]) {
+      event.preventDefault();
+      actionMap[action]();
+    }
+  });
+  window.addEventListener("visibilitychange", function() {
+    isPageVisible = document.visibilityState !== 'hidden';
+    postMessageToWorker('pageVisibilityChanged', isPageVisible);
+    removeNewPullRequestAnimations();
+  });
+}
+
+/**
+ * Toggle the loading class (which drops opacity) on repositories
+ * @param {String|Number} id - if of the element we are updating
+ * @param {String} url - url of the element we are updating
+ * @param {Boolean} isLoading - toggle showing loading state or not
+ */
+export function toggleLoadingRepository([url, isLoading]) {
+  let article = document.querySelector(`[data-url="${url}"]`);
+
+  if (!article) {
+    notify(`${url} doesn't exist on the page`);
+    return;
+  }
+
+  if (isLoading) {
+    article.classList.add('loading');
+    return;
+  }
+  article.classList.remove('loading');
+}
+
+/**
+ * Draw a simple placeholder repo into the repoSection.
+ * Later we will fill up the drawn element with more data.
+ * @param {Object} Repo - Repo Object
+ * @return {Element} article - placeholder element
+ */
+export function drawPlaceholderRepo({url}) {
+  let lastRepo = repoSection.lastElementChild;
+
+  let article = document.createElement('article');
+  article.setAttribute('class', 'bubble repository loading');
+  article.setAttribute('data-url', url);
+
+  let repositoryInner = document.createElement('div');
+  repositoryInner.setAttribute('class', 'repositoryInner');
+
+  let header = document.createElement('header');
+  let title = document.createElement('span');
+  title.setAttribute('class', 'repo-title');
+
+  let actionsElement = document.createElement('div');
+  let repoLink = document.createElement('a');
+  let sync = document.createElement('a');
+  let trash = document.createElement('a');
+  let href = `${githubUrl}${url}`;
+  let actions = [
+    {elem: repoLink, action: '', className: 'repo', href},
+    {elem: sync, action: 'refresh', className: 'sync'},
+    {elem: trash, action: 'remove', className: 'x'}
+  ];
+  actions.forEach(({elem, action, className, href}) => {
+    elem.setAttribute('href', href || '#');
+    elem.setAttribute('target', 'blank');
+    elem.setAttribute('data-action', action);
+    elem.setAttribute('class', `octicon octicon-${className} action`);
+    elem.setAttribute('data-url', url);
+  });
+
+  let prListItems = document.createElement('ul');
+  prListItems.setAttribute('class', 'prList');
+
+  if (lastRepo) {
+    let firstChild = lastRepo.firstElementChild;
+    article.style.cssText = lastRepo.getAttribute('style');
+    repositoryInner.style.cssText = firstChild.getAttribute('style');
+  }
+
+  article
+    .appendChild(repositoryInner)
+    .appendChild(header)
+    .appendChild(title)
+    .appendChild(document.createTextNode(url));
+
+  repositoryInner.appendChild(prListItems);
+  actions.forEach(({elem}) => actionsElement.appendChild(elem));
+  repositoryInner.appendChild(actionsElement);
+
+  // The Repo is built, lets append it!
+  repoSection.appendChild(article);
+  addLocalRepo(url);
+  updateShareLink();
+
+  // Now that we've added a placeholder, lets spin to win!
+  // The 100ms delay adds a cool animation effect
+  setTimeout(updateRotations, 100);
+
+  return article;
+}
+
+/**
+ * Remove a repository from the DOM
+ * @param {String} url - repositories have a data-url="" to target from
+ */
+export function removeRepository(url) {
+  let article = document.querySelector(`[data-url="${url}"]`);
+  if (!article) {
+    notify(`${url} doesn't exist on the page`);
+    return;
+  }
+  article.parentNode.removeChild(article);
+  removeLocalRepo(url);
+  updateShareLink();
+
+  setTimeout(updateRotations, 100);
+}
+
+/**
+ * Update the repository article element with any changes
+ * @param {Object} repository - Repository Details
+ * @param {Element} placeholder - Placeholder Element
+ */
+export function updateRepository(repository) {
+  let {id, name, url, fullName, placeholderUpdated, prs} = repository;
+  let article = document.getElementById(id) ||
+    document.querySelector(`[data-url="${url}"]`);
+
+  if (!article) {
+    article = drawPlaceholderRepo(repository);
+  }
+
+  // If we have not had the opportunity to the DOM earlier, do it now.
+  if (!placeholderUpdated) {
+    // If there wasn't an id before, set it now
+    if (!article.id) {
+      article.setAttribute('id', id);
+    }
+
+    let actions = article.querySelectorAll('[data-action]');
+    let actionSize = actions.length;
+    for (let index = 0; index < actionSize; index++) {
+      let action = actions[index];
+      action.setAttribute('data-id', id);
+    }
+
+    // Swap out the title with a better one
+    let repoTitle = article.querySelector('.repo-title');
+    repoTitle.innerText = name;
+    repoTitle.setAttribute('title', fullName);
+
+    repository.placeholderUpdated = true;
+  }
+
+  let prListItems = article.querySelector('.prList');
+  let pullRequestFragment = document.createDocumentFragment();
+
+  if (prs.length > prResizeThreshold) {
+    prListItems.classList.add('lotsOfPRs');
+  } else {
+    prListItems.classList.remove('lotsOfPRs');
+  }
+
+  prs.forEach(({id, title, url}) => {
+    let prListItem = document.getElementById(id);
+    let prMoreInfo;
+    if (prListItem) {
+      prMoreInfo = prListItem.querySelector('.prMoreInfo');
+      prMoreInfo.innerText = title;
+      return pullRequestFragment.appendChild(prListItem);
+    }
+
+    prListItem = document.createElement('li');
+    let prLink = document.createElement('a');
+    prMoreInfo = document.createElement('span');
+
+    prListItem.setAttribute('id', id);
+
+    prLink.setAttribute('href', url);
+    prLink.setAttribute('target', '_blank');
+    prLink.setAttribute('class', 'prLink octicon octicon-git-pull-request');
+
+    prListItem.classList.add('prListItem');
+    prMoreInfo.classList.add('prMoreInfo');
+
+    pullRequestFragment
+      .appendChild(prListItem)
+      .appendChild(prLink)
+      .appendChild(prMoreInfo)
+      .appendChild(document.createTextNode(title));
+  });
+
+  prListItems.innerHTML = '';
+  prListItems.appendChild(pullRequestFragment);
+
+  article.classList.remove('loading');
+}
+
+/**
+ * Remove the "highlight" style from newly added pull requests...
+ * only when the user is looking at the page.  Otherwise, we
+ * continue queing them up for later.
+ */
+export function removeNewPullRequestAnimations() {
+  if (!isPageVisible) {
+    return;
+  }
+  newPRQueue.forEach(id => {
+    let element = document.getElementById(id);
+    if (!element) {
+      return;
+    }
+    setTimeout(() => {
+      element.classList.remove('newPullRequest');
+    }, 1000);
+  });
+  newPRQueue = [];
+}
+
+/**
+ * Given an array of pull request ids, add a "newPullRequest" class and remove it
+ * @param {Array} ids - array of pull request ids
+ */
+export function animateNewPullRequests(ids) {
+  ids.forEach(id => {
+    let element = document.getElementById(id);
+    if (!element) {
+      return;
+    }
+    element.classList.add('newPullRequest');
+  });
+  newPRQueue.push(...ids);
+  removeNewPullRequestAnimations();
+}
+
+registerWorkerEventHandles('RepoSection', {
+  drawPlaceholderRepo,
+  animateNewPullRequests,
+  updateRepository,
+  removeRepository,
+  toggleLoadingRepository
+});

--- a/public/scripts/utilities.js
+++ b/public/scripts/utilities.js
@@ -1,6 +1,4 @@
 
-import {registerWorkerEventHandles} from './conductor';
-
 let logsEnabled = true;
 
 /**
@@ -57,5 +55,3 @@ export function notify(notifyText, duration = 1000) {
 export function shh() {
   logsEnabled = false;
 }
-
-registerWorkerEventHandles('Utility', {log, notify});

--- a/tests/actionPanel.js
+++ b/tests/actionPanel.js
@@ -2,10 +2,11 @@
 import test from 'ava';
 
 import {registerWorker} from '../public/scripts/conductor';
+import {getWorker} from './helpers/octoTestHelpers';
 
 let hasRefreshed;
 let updateShareLink;
-let loadActionPanelListeners;
+let loadActionPanel;
 
 function resetDOMAndActionPanel() {
   let {shh} = require('../public/scripts/utilities');
@@ -53,22 +54,7 @@ function resetDOMAndActionPanel() {
   let actionPanel = require('../public/scripts/actionPanel');
   hasRefreshed = actionPanel.hasRefreshed;
   updateShareLink = actionPanel.updateShareLink;
-  loadActionPanelListeners = actionPanel.loadActionPanelListeners;
-}
-
-/**
- * Return a fake worker. We aren't testing communicating back and forth between
- * the worker and other modules, so all we really need to do is spoof a worker
- * by passing in adEventListener and postMessage functions.
- * @param {Function} addEventListener - gets called when worker is registered
- * @param {Function} postMessage - gets called when modules do a postMessage to conductor
- * @return {Object} Fake Worker
- */
-function getWorker(addEventListener, postMessage) {
-  return {
-    addEventListener,
-    postMessage
-  };
+  loadActionPanel = actionPanel.loadActionPanel;
 }
 
 test.beforeEach(resetDOMAndActionPanel);
@@ -83,14 +69,14 @@ test('startRefreshing called on load', t => {
   let worker = getWorker(addEventListener, postMessage);
 
   registerWorker(worker);
-  loadActionPanelListeners();
+  loadActionPanel();
 });
 
 test('toggling refreshRate changes', t => {
 
   return new Promise(function(resolve) {
 
-    let {refreshRateOptions} = loadActionPanelListeners();
+    let {refreshRateOptions} = loadActionPanel();
 
     let addEventListener = () => {};
     let postMessage = (result) => {
@@ -134,7 +120,7 @@ test('request notification permissions', t => {
   let worker = getWorker(addEventListener, postMessage);
 
   registerWorker(worker);
-  let {requestNotifications} = loadActionPanelListeners();
+  let {requestNotifications} = loadActionPanel();
   requestNotifications.click();
 });
 
@@ -152,7 +138,7 @@ test('toggle more info', t => {
     let worker = getWorker(addEventListener, postMessage);
 
     registerWorker(worker);
-    let {moreInfoToggle} = loadActionPanelListeners();
+    let {moreInfoToggle} = loadActionPanel();
     moreInfoToggle.click();
 
     setTimeout(() => {
@@ -170,7 +156,7 @@ test('toggleViewType', t => {
   let worker = getWorker(addEventListener, postMessage);
 
   registerWorker(worker);
-  let {appElement, toggleViewType} = loadActionPanelListeners();
+  let {appElement, toggleViewType} = loadActionPanel();
   t.is(appElement.classList.contains('octoInline'), false);
   toggleViewType.click();
   t.is(appElement.classList.contains('octoInline'), true);
@@ -184,7 +170,7 @@ test('refreshRateToggle and shareToggle', t => {
   let worker = getWorker(addEventListener, postMessage);
 
   registerWorker(worker);
-  let {refreshRateToggle, shareToggle, shareContent, refreshContent} = loadActionPanelListeners();
+  let {refreshRateToggle, shareToggle, shareContent, refreshContent} = loadActionPanel();
 
   // Both should initially be off
   t.is(shareContent.classList.contains('toggle'), false);
@@ -318,6 +304,6 @@ test('missing moreInfoToggle doesn\'t explode the app', t => {
   delete require.cache[require.resolve('../public/scripts/actionPanel')];
   let actionPanel = require('../public/scripts/actionPanel');
 
-  actionPanel.loadActionPanelListeners();
+  actionPanel.loadActionPanel();
   t.pass();
 });

--- a/tests/addRepo.js
+++ b/tests/addRepo.js
@@ -2,26 +2,10 @@
 import test from 'ava';
 
 import {registerWorker} from '../public/scripts/conductor';
+import {getWorker} from './helpers/octoTestHelpers';
 
-let loadAddRepoListeners;
+let loadAddRepoSection;
 let setInitialFetch;
-let initAPIVariables;
-
-/**
- * Return a fake worker. We aren't testing communicating back and forth between
- * the worker and other modules, so all we really need to do is spoof a worker
- * by passing in addEventListener and postMessage functions.
- * @param {Function} addEventListener - gets called when worker is registered
- * @param {Function} postMessage - gets called when modules do a postMessage to conductor
- * @return {Object} Fake Worker
- */
-function getWorker(addEventListener, postMessage) {
-  return {
-    fns: {},
-    addEventListener,
-    postMessage
-  };
-}
 
 test.beforeEach(() => {
   let {shh} = require('../public/scripts/utilities');
@@ -45,43 +29,8 @@ test.beforeEach(() => {
    `);
   delete require.cache[require.resolve('../public/scripts/addRepo')];
   let addRepo = require('../public/scripts/addRepo');
-  loadAddRepoListeners = addRepo.loadAddRepoListeners;
+  loadAddRepoSection = addRepo.loadAddRepoSection;
   setInitialFetch = addRepo.setInitialFetch;
-  initAPIVariables = addRepo.initAPIVariables;
-});
-
-test('initAPIVariables should postMessage api variables to the web worker', t => {
-  let addEventListener = () => {};
-  let postMessage = (result) => {
-    let [fnName, fnData] = result;
-    let {postData} = JSON.parse(fnData);
-    let { accessToken, apiUrl, githubUrl } = postData;
-    t.is(fnName, 'initAPIVariables');
-    t.is(accessToken, 'accessToken');
-    t.is(apiUrl, 'apiUrl');
-    t.is(githubUrl, 'githubUrl');
-  };
-  let worker = getWorker(addEventListener, postMessage);
-
-  registerWorker(worker);
-  initAPIVariables({accessToken: 'accessToken', apiUrl: 'apiUrl', githubUrl: 'githubUrl'});
-});
-
-test('initAPIVariables should postMessage defaults if values aren\'t provided', t => {
-  let addEventListener = () => {};
-  let postMessage = (result) => {
-    let [fnName, fnData] = result;
-    let {postData} = JSON.parse(fnData);
-    let { accessToken, apiUrl, githubUrl } = postData;
-    t.is(fnName, 'initAPIVariables');
-    t.is(accessToken, '');
-    t.is(apiUrl, 'https://api.github.com');
-    t.is(githubUrl, 'https://github.com/');
-  };
-  let worker = getWorker(addEventListener, postMessage);
-
-  registerWorker(worker);
-  initAPIVariables({});
 });
 
 test('addRepoForm should trigger addRepo on submissions', t => {
@@ -119,7 +68,7 @@ test('addRepoForm should trigger addRepo on submissions', t => {
   let worker = getWorker(addEventListener, postMessage);
   registerWorker(worker);
 
-  let {addRepoForm, addRepoInput} = loadAddRepoListeners();
+  let {addRepoForm, addRepoInput} = loadAddRepoSection();
 
   ['user/repo1', 'user/repo2', 'user/repo3'].forEach(repo => {
     addRepoInput.value = repo;
@@ -131,7 +80,7 @@ test('addRepoForm should trigger addRepo on submissions', t => {
 
 test('addRepoInput input event should clean up the input', t => {
 
-  let {addRepoInput} = loadAddRepoListeners();
+  let {addRepoInput} = loadAddRepoSection();
 
   ['https://github.com/user/repo1', 'https://github.com/user/repo1/issues', 'user/repo1/', 'user/repo1/issues', 'user/repo1']
     .forEach(inputVal => {
@@ -159,7 +108,7 @@ test('syncAll should trigger getAllRepoDetails', t => {
   let worker = getWorker(addEventListener, postMessage);
   registerWorker(worker);
 
-  let {syncAll} = loadAddRepoListeners();
+  let {syncAll} = loadAddRepoSection();
 
   syncAll.click();
 })
@@ -207,7 +156,7 @@ test('click authStatus should open a window that postMessages back', t => {
     let worker = getWorker(addEventListener, postMessage);
     registerWorker(worker);
 
-    let listenerElements = loadAddRepoListeners();
+    let listenerElements = loadAddRepoSection();
     authStatus = listenerElements.authStatus;
 
     authStatus.click();
@@ -247,7 +196,7 @@ test('click authStatus should NOT handle a postMessages from a different origin'
     let worker = getWorker(addEventListener, postMessage);
     registerWorker(worker);
 
-    let listenerElements = loadAddRepoListeners();
+    let listenerElements = loadAddRepoSection();
     authStatus = listenerElements.authStatus;
 
     authStatus.click();
@@ -273,53 +222,6 @@ test('app should not explode if authStatus isn\'t on the DOM', t => {
    `);
   delete require.cache[require.resolve('../public/scripts/addRepo')];
   let addRepo = require('../public/scripts/addRepo');
-  addRepo.loadAddRepoListeners();
+  addRepo.loadAddRepoSection();
   t.pass();
-});
-
-test('setInitialFetch should call appropriate addRepos', t => {
-
-  let expectedRepos = ['user/repo3', 'user/repo2', 'user/repo1'];
-
-  function postMessage(message) {
-    if (!message) {
-      message = [];
-    }
-
-    let fnName = message[0];
-    let postData = message[1];
-
-    if (fnName === 'addRepo') {
-      let fnData = JSON.parse(postData);
-      if (expectedRepos) {
-        t.is(expectedRepos[expectedRepos.length -1], fnData.postData);
-        expectedRepos.pop();
-      }
-      if (!expectedRepos.length) {
-        return t.pass();
-      }
-    }
-
-    if (this.fns.message) {
-      this.fns.message({
-        data: [fnName, postData]
-      });
-    }
-  }
-  function addEventListener(type, fn) {
-    this.fns[type] = fn;
-  }
-
-  let worker = getWorker(addEventListener, postMessage);
-
-  registerWorker(worker);
-
-  let repoStateManager = {
-    fetch(addRepo) {
-      addRepo('user/repo1');
-    }
-  };
-  let sharedRepos = ['user/repo2', 'user/repo3'];
-  setInitialFetch(repoStateManager, sharedRepos);
-  worker.postMessage(['apiInitialized', '{}']);
 });

--- a/tests/helpers/octoTestHelpers.js
+++ b/tests/helpers/octoTestHelpers.js
@@ -1,0 +1,17 @@
+
+
+/**
+ * Return a fake worker. We aren't testing communicating back and forth between
+ * the worker and other modules, so all we really need to do is spoof a worker
+ * by passing in addEventListener and postMessage functions.
+ * @param {Function} addEventListener - gets called when worker is registered
+ * @param {Function} postMessage - gets called when modules do a postMessage to conductor
+ * @return {Object} Fake Worker
+ */
+export function getWorker(addEventListener, postMessage) {
+  return {
+    fns: {},
+    addEventListener,
+    postMessage
+  };
+}

--- a/tests/helpers/setup-browser-env.js
+++ b/tests/helpers/setup-browser-env.js
@@ -8,6 +8,11 @@ global.fetch = () => {};
 // Dummy Browser Apis
 global.Notification = () => {close()  };
 global.localStorage = {
-  getItem(){},
-  setItem(){}
+  items: {},
+  getItem(name){
+    return this.items[name];
+  },
+  setItem(name, value){
+    this.items[name] = value;
+  }
 };

--- a/tests/localRepoState.js
+++ b/tests/localRepoState.js
@@ -1,0 +1,58 @@
+
+import test from 'ava';
+
+import {registerWorker} from '../public/scripts/conductor';
+
+let addLocalRepo;
+let removeLocalRepo;
+let getLocalRepos;
+let fetchLocalRepos;
+
+test.beforeEach(() => {
+  let {shh} = require('../public/scripts/utilities');
+  shh();
+  delete require.cache[require.resolve('../public/scripts/localRepoState')];
+  let localRepoState = require('../public/scripts/localRepoState');
+
+  addLocalRepo = localRepoState.addLocalRepo;
+  removeLocalRepo = localRepoState.removeLocalRepo;
+  getLocalRepos = localRepoState.getLocalRepos;
+  fetchLocalRepos = localRepoState.fetchLocalRepos;
+});
+
+test('add and get a localRepo', t => {
+  addLocalRepo('octoshelf/octoshelf-webapp');
+  let repos = getLocalRepos();
+  t.is(repos[0], 'octoshelf/octoshelf-webapp');
+});
+
+test('duplicates should not get added', t => {
+  addLocalRepo('octoshelf/octoshelf-webapp');
+  addLocalRepo('octoshelf/octoshelf-webapp');
+
+  let repos = getLocalRepos();
+  t.is(repos[0], 'octoshelf/octoshelf-webapp');
+  t.is(repos.length, 1);
+});
+
+test('removeLocalRepo', t => {
+  addLocalRepo('octoshelf/octoshelf-webapp');
+  let repos = getLocalRepos();
+  t.is(repos.length, 1);
+
+  removeLocalRepo('octoshelf/octoshelf-webapp');
+  repos = getLocalRepos();
+  t.is(repos.length, 0);
+});
+
+test('getLocalRepos', t => {
+  addLocalRepo('octoshelf/octoshelf-webapp');
+  addLocalRepo('octoshelf/docs');
+  t.deepEqual(getLocalRepos(), ['octoshelf/octoshelf-webapp', 'octoshelf/docs']);
+});
+
+test('getLocalRepos should not blow up if empty', t => {
+  global.localStorage.items = {};
+  getLocalRepos();
+  t.pass();
+});

--- a/tests/repoSection.js
+++ b/tests/repoSection.js
@@ -1,0 +1,86 @@
+
+import test from 'ava';
+
+import {registerWorker} from '../public/scripts/conductor';
+
+let loadRepoSection;
+let toggleLoadingRepository;
+let drawPlaceholderRepo;
+let removeRepository;
+let updateRepository;
+let removeNewPullRequestAnimations;
+let animateNewPullRequests;
+
+test.beforeEach(() => {
+  let {shh} = require('../public/scripts/utilities');
+  shh();
+  global.document = require('jsdom').jsdom(`
+    <div id="octoshelf">
+      <section class="app-repositoriesWrapper">
+          <section id="repoSection" class="app-repositories">
+            <article class="bubble repository" data-url="octoshelf/octoshelf-webapp">
+              <div class="repositoryInner" style="transform: rotate(-0deg);">
+                <header>
+                  <span class="repo-title" title="OctoShelf/octoshelf-webapp">octoshelf-webapp</span>
+                </header>
+                <ul class="prList"></ul>
+                <div>
+                  <a href="https://github.com/octoshelf/octoshelf-webapp" target="blank" data-action="" class="octicon octicon-repo action" data-url="octoshelf/octoshelf-webapp" data-id="59803443"></a>
+                  <a href="#" target="blank" data-action="refresh" class="octicon octicon-sync action" data-url="octoshelf/octoshelf-webapp" data-id="59803443"></a><a href="#" target="blank" data-action="remove" class="octicon octicon-x action" data-url="octoshelf/octoshelf-webapp" data-id="59803443"></a>
+                </div>
+              </div>
+            </article>
+          </section>
+      </section>
+      <section id="actionPanel"><textarea id="shareUrl"></textarea></section>
+      <section id="notifications"></section>
+    </div>
+   `);
+  delete require.cache[require.resolve('../public/scripts/repoSection')];
+  let repoSection = require('../public/scripts/repoSection');
+
+  loadRepoSection = repoSection.loadRepoSection;
+  toggleLoadingRepository = repoSection.toggleLoadingRepository;
+  drawPlaceholderRepo = repoSection.drawPlaceholderRepo;
+  removeRepository = repoSection.removeRepository;
+  updateRepository = repoSection.updateRepository;
+  removeNewPullRequestAnimations = repoSection.removeNewPullRequestAnimations;
+  animateNewPullRequests = repoSection.animateNewPullRequests;
+});
+
+
+test('removeRepository should remove a repository', t => {
+  let repoSection = global.document.getElementById('repoSection');
+  t.is(global.document.getElementById('repoSection').children.length, 1);
+  removeRepository('octoshelf/octoshelf-webapp');
+  t.is(global.document.getElementById('repoSection').children.length, 0);
+});
+
+test('removing a non-existant repository should notify what happened', t => {
+  removeRepository('notHere/notHere');
+  let firstNotification = global.document.getElementById('notifications').firstElementChild;
+  t.is(firstNotification.textContent, 'notHere/notHere doesn\'t exist on the page');
+  t.pass();
+});
+
+test('toggleLoadingRepository should add and remove loading class', t => {
+  let repo = global.document.getElementById('repoSection').firstElementChild;
+
+  t.is(repo.classList.contains('loading'), false);
+  toggleLoadingRepository(['octoshelf/octoshelf-webapp', true]);
+  t.is(repo.classList.contains('loading'), true);
+  toggleLoadingRepository(['octoshelf/octoshelf-webapp', false]);
+  t.is(repo.classList.contains('loading'), false);
+});
+
+test('toggleLoadingRepository a non-existant repo should notify', t => {
+  toggleLoadingRepository(['notHere/notHere', true]);
+  let firstNotification = global.document.getElementById('notifications').firstElementChild;
+  t.is(firstNotification.textContent, 'notHere/notHere doesn\'t exist on the page');
+});
+
+test.todo('loadRepoSection');
+test.todo('drawPlaceholderRepo');
+test.todo('updateRepository');
+test.todo('removeNewPullRequestAnimations');
+test.todo('animateNewPullRequests');


### PR DESCRIPTION
Adding a Repo Section to maintain the repo `<article>`s UI. I pulled
out most of the code from `OctoShelf.js`.

`OctoShelf.js`'s responsibility is to send the githubUrl + apiUrl
to the web worker, and to load the other components.

And with this, I wrote a bunch of tests. Still have a small handful
of tests to write for `repoSection`, but I've been sitting on this
revision for a few days, so I wanted to get something out there and
think it through before green-button'ing.
